### PR TITLE
V2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     terminal (2.0.0)
       escape_utils (~> 1.0)
-      gemoji (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +10,6 @@ GEM
     benchmark-ips (2.1.1)
     diff-lcs (1.2.5)
     escape_utils (1.0.1)
-    gemoji (2.1.0)
     hirb (0.7.3)
     memory_profiler (0.0.4)
     method_profiler (2.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    terminal (1.0.2)
+    terminal (2.0.0)
       escape_utils (~> 1.0)
       gemoji (~> 2.1)
 

--- a/Readme.md
+++ b/Readme.md
@@ -51,15 +51,6 @@ Now in your views:
 <div class="term-container"><%= Terminal.render(output) %></div>
 ```
 
-### Emojis :+1:
-
-Terminal converts unicode to proper `<img>` tags. We use the [gemoji](https://github.com/github/gemoji)
-gem to do this. The path to the assets can be customized by passing the `:emoji_asset_path` option to `Terminal.render`
-
-```ruby
-Terminal.render(output, emoji_asset_path: "https://your.cdn.com/images/emoji")
-```
-
 ### Command Line
 
 Terminal ships with a command line utility. For example, you can pipe `rspec` output to it:

--- a/bin/terminal
+++ b/bin/terminal
@@ -6,18 +6,13 @@ $:.unshift(File.join(File.expand_path(File.dirname(__FILE__)), '..', 'lib'))
 require 'terminal'
 require 'optparse'
 
-options = Struct.new(:preview,
-                     :emoji_asset_path).new
+options = Struct.new(:preview).new
 
 option_parser = OptionParser.new do |opts|
   opts.banner = "Usage: #{opts.program_name} [options] <input file>"
 
   opts.on("--preview", "Preview in the browser") do
     options.preview = true
-  end
-
-  opts.on("--emoji-asset-path=PATH", "Path or URL to emoji image files") do |path|
-    options.emoji_asset_path = path
   end
 
   opts.on_tail("-h", "--help", "Show this help documentation") do
@@ -36,7 +31,7 @@ if ($stdin.tty? && ARGV.empty?)
 end
 
 raw = ARGF.read
-rendered = Terminal.render(raw, emoji_asset_path: options[:emoji_asset_path])
+rendered = Terminal.render(raw)
 
 if options[:preview]
   require 'tempfile'

--- a/lib/terminal/renderer.rb
+++ b/lib/terminal/renderer.rb
@@ -1,7 +1,6 @@
 # encoding: UTF-8
 
 require 'escape_utils'
-require 'emoji'
 require 'strscan'
 
 module Terminal

--- a/lib/terminal/version.rb
+++ b/lib/terminal/version.rb
@@ -1,3 +1,3 @@
 module Terminal
-  VERSION = "1.0.2"
+  VERSION = "2.0.0"
 end

--- a/spec/terminal/renderer_spec.rb
+++ b/spec/terminal/renderer_spec.rb
@@ -20,13 +20,6 @@ describe Terminal::Renderer do
   end
 
   describe "#render" do
-    it "chops off logs longer than 4 megabytes" do
-      long_string = "x" * 5 * 1024 * 1024
-      last_part_of_long_string = render(long_string).split("").last(1000).join("")
-
-      expect(last_part_of_long_string).to end_with("Warning: Terminal has chopped off the rest of the build as it&#39;s over the allowed 4 megabyte limit for logs.")
-    end
-
     it "closes colors that get opened" do
       raw = "he\033[32mllo"
 
@@ -194,31 +187,6 @@ describe Terminal::Renderer do
       raw = "hi amazing \e[12 nom nom nom friends"
 
       expect(render(raw)).to eql("hi amazing \e[12 nom nom nom friends")
-    end
-
-    it "renders unicode emoji" do
-      raw = "this is great 👍"
-
-      expect(render(raw)).to eql(%{this is great <img alt="+1" title="+1" src="/assets/emojis/unicode/1f44d.png" class="emoji" width="20" height="20" />})
-    end
-
-    it "returns nothing if the unicode emoji can't be found" do
-      expect(Emoji).to receive(:unicodes_index) { {} }
-      raw = "this is great 😎"
-
-      expect(render(raw)).to eql(%{this is great 😎})
-    end
-
-    it "leaves the tick emoji alone (it looks better and is colored)" do
-      raw = "works ✔"
-
-      expect(render(raw)).to eql(%{works ✔})
-    end
-
-    it "leaves the ✖ emoji alone as well" do
-      raw = "broke ✖"
-
-      expect(render(raw)).to eql(%{broke ✖})
     end
 
     it "handles colors with 3 attributes" do

--- a/terminal.gemspec
+++ b/terminal.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "escape_utils", "~> 1.0"
-  spec.add_dependency "gemoji", "~> 2.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Removes the emoji and string encoding munging, which can easily be done outside the gem. This means we can easily just replace this gem with the golang version (#11)