### PR TITLE
Rewrite parser state machine

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,101 @@
+package terminal
+
+import "unicode"
+
+// Stateful container object for capturing escape codes
+type escapeCode struct {
+	instructions    []string
+	buffer          []rune
+	nextInstruction []rune
+	code            rune
+}
+
+const (
+	MODE_NORMAL = iota
+	MODE_ESCAPE = iota
+)
+
+type parser struct {
+	mode   int
+	escape escapeCode
+	screen *screen
+}
+
+func newParser(s *screen) parser {
+	return parser{
+		mode:   MODE_NORMAL,
+		screen: s,
+	}
+}
+
+func (p *parser) parse(ansi []byte) {
+	for _, char := range string(ansi) {
+		switch p.mode {
+		case MODE_ESCAPE:
+			p.parseEscape(char)
+		case MODE_NORMAL:
+			p.parseNormal(char)
+		}
+	}
+}
+
+func (p *parser) parseEscape(char rune) {
+	p.escape.buffer = append(p.escape.buffer, char)
+	if len(p.escape.buffer) == 2 {
+		if char != '[' {
+			// Not really an escape code, abort
+			p.screen.appendMany(p.escape.buffer)
+			p.mode = MODE_NORMAL
+		}
+	} else {
+		char = unicode.ToUpper(char)
+		switch char {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			p.escape.nextInstruction = append(p.escape.nextInstruction, char)
+		case ';':
+			p.escape.endOfInstruction()
+		case 'Q', 'K', 'G', 'A', 'B', 'C', 'D', 'M':
+			p.escape.code = char
+			p.escape.endOfInstruction()
+			p.screen.applyEscape(p.escape)
+			p.mode = MODE_NORMAL
+		default:
+			// abort the escapeCode
+			p.screen.appendMany(p.escape.buffer)
+			p.mode = MODE_NORMAL
+		}
+	}
+}
+
+func (p *parser) parseNormal(char rune) {
+	switch char {
+	case '\n':
+		p.screen.x = 0
+		p.screen.y++
+	case '\r':
+		p.screen.x = 0
+	case '\b':
+		if p.screen.x > 0 {
+			p.screen.x--
+		}
+	case '\x1b':
+		p.escape = escapeCode{buffer: []rune{char}}
+		p.mode = MODE_ESCAPE
+	default:
+		p.screen.append(char)
+	}
+}
+
+// Reset our instruction buffer & add to our instruction list
+func (e *escapeCode) endOfInstruction() {
+	e.instructions = append(e.instructions, string(e.nextInstruction))
+	e.nextInstruction = []rune{}
+}
+
+// First instruction for this escape code, if we have one.
+func (e *escapeCode) firstInstruction() string {
+	if len(e.instructions) == 0 {
+		return ""
+	}
+	return e.instructions[0]
+}

--- a/parser.go
+++ b/parser.go
@@ -84,11 +84,12 @@ func (p *parser) parseNormal(char rune) {
 }
 
 func (p *parser) parsePreEscape(char rune) {
-	if char == '[' {
+	switch char {
+	case '[':
 		p.instructionStartedAt = p.cursor + utf8.RuneLen('[')
 		p.instructions = make([]string, 0, 1)
 		p.mode = MODE_ESCAPE
-	} else {
+	default:
 		// Not an escape code, false alarm
 		p.cursor = p.escapeStartedAt
 		p.mode = MODE_NORMAL

--- a/parser.go
+++ b/parser.go
@@ -21,14 +21,8 @@ type parser struct {
 	screen *screen
 }
 
-func newParser(s *screen) parser {
-	return parser{
-		mode:   MODE_NORMAL,
-		screen: s,
-	}
-}
-
 func (p *parser) parse(ansi []byte) {
+	p.mode = MODE_NORMAL
 	for _, char := range string(ansi) {
 		switch p.mode {
 		case MODE_ESCAPE:
@@ -57,7 +51,7 @@ func (p *parser) parseEscape(char rune) {
 		case 'Q', 'K', 'G', 'A', 'B', 'C', 'D', 'M':
 			p.escape.code = char
 			p.escape.endOfInstruction()
-			p.screen.applyEscape(p.escape)
+			p.screen.applyEscape(char, p.escape.instructions)
 			p.mode = MODE_NORMAL
 		default:
 			// abort the escapeCode

--- a/parser.go
+++ b/parser.go
@@ -51,10 +51,10 @@ func (p *parser) parseEscape(char rune) {
 	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 		// Part of an instruction
 	case ';':
-		p.endOfInstruction()
+		p.addInstruction()
 		p.instructionStartedAt = p.cursor + utf8.RuneLen(';')
 	case 'Q', 'K', 'G', 'A', 'B', 'C', 'D', 'M':
-		p.endOfInstruction()
+		p.addInstruction()
 		p.screen.applyEscape(char, p.instructions)
 		p.mode = MODE_NORMAL
 	default:
@@ -67,14 +67,11 @@ func (p *parser) parseEscape(char rune) {
 func (p *parser) parseNormal(char rune) {
 	switch char {
 	case '\n':
-		p.screen.x = 0
-		p.screen.y++
+		p.screen.newLine()
 	case '\r':
-		p.screen.x = 0
+		p.screen.carriageReturn()
 	case '\b':
-		if p.screen.x > 0 {
-			p.screen.x--
-		}
+		p.screen.backspace()
 	case '\x1b':
 		p.escapeStartedAt = p.cursor
 		p.mode = MODE_PRE_ESCAPE
@@ -96,8 +93,7 @@ func (p *parser) parsePreEscape(char rune) {
 	}
 }
 
-// Reset our instruction buffer & add to our instruction list
-func (p *parser) endOfInstruction() {
+func (p *parser) addInstruction() {
 	instruction := string(p.ansi[p.instructionStartedAt:p.cursor])
 	p.instructions = append(p.instructions, instruction)
 }

--- a/screen.go
+++ b/screen.go
@@ -149,8 +149,7 @@ func (s *screen) applyEscape(code rune, instructions []string) {
 func (s *screen) parse(ansi []byte) {
 	s.style = &emptyStyle
 
-	p := parser{screen: s}
-	p.parse(ansi)
+	parseANSIToScreen(s, ansi)
 }
 
 func (s *screen) asHTML() []byte {

--- a/screen.go
+++ b/screen.go
@@ -114,14 +114,19 @@ func (s *screen) color(i []string) {
 }
 
 // Apply an escape sequence to the screen
-func (s *screen) applyEscape(e escapeCode) {
-	switch e.code {
+func (s *screen) applyEscape(code rune, instructions []string) {
+	if len(instructions) == 0 {
+		// Ensure we always have a first instruction
+		instructions = []string{""}
+	}
+
+	switch code {
 	case 'M':
-		s.color(e.instructions)
+		s.color(instructions)
 	case 'G':
 		s.x = 0
 	case 'K':
-		switch e.firstInstruction() {
+		switch instructions[0] {
 		case "0", "":
 			s.clear(s.y, s.x, screenEndOfLine)
 		case "1":
@@ -130,13 +135,13 @@ func (s *screen) applyEscape(e escapeCode) {
 			s.clear(s.y, screenStartOfLine, screenEndOfLine)
 		}
 	case 'A':
-		s.up(e.firstInstruction())
+		s.up(instructions[0])
 	case 'B':
-		s.down(e.firstInstruction())
+		s.down(instructions[0])
 	case 'C':
-		s.forward(e.firstInstruction())
+		s.forward(instructions[0])
 	case 'D':
-		s.backward(e.firstInstruction())
+		s.backward(instructions[0])
 	}
 }
 
@@ -144,7 +149,7 @@ func (s *screen) applyEscape(e escapeCode) {
 func (s *screen) parse(ansi []byte) {
 	s.style = &emptyStyle
 
-	p := newParser(s)
+	p := parser{screen: s}
 	p.parse(ansi)
 }
 

--- a/screen.go
+++ b/screen.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"unicode"
 )
 
 // A terminal 'screen'. Current cursor position, cursor style, and characters
@@ -13,14 +12,6 @@ type screen struct {
 	y      int
 	screen [][]node
 	style  *style
-}
-
-// Stateful container object for capturing escape codes
-type escapeCode struct {
-	instructions    []string
-	buffer          []rune
-	nextInstruction []rune
-	code            rune
 }
 
 const screenEndOfLine = -1
@@ -149,99 +140,12 @@ func (s *screen) applyEscape(e escapeCode) {
 	}
 }
 
-// Reset our instruction buffer & add to our instruction list
-func (e *escapeCode) endOfInstruction() {
-	e.instructions = append(e.instructions, string(e.nextInstruction))
-	e.nextInstruction = []rune{}
-}
-
-// First instruction for this escape code, if we have one.
-func (e *escapeCode) firstInstruction() string {
-	if len(e.instructions) == 0 {
-		return ""
-	}
-	return e.instructions[0]
-}
-
-const (
-	MODE_NORMAL = iota
-	MODE_ESCAPE = iota
-)
-
-type parser struct {
-	mode   int
-	escape escapeCode
-	screen *screen
-}
-
-func newParser(s *screen) parser {
-	return parser{
-		mode:   MODE_NORMAL,
-		screen: s,
-	}
-}
-
 // Parse ANSI input, populate our screen buffer with nodes
 func (s *screen) parse(ansi []byte) {
 	s.style = &emptyStyle
 
 	p := newParser(s)
-
-	for _, char := range string(ansi) {
-		switch p.mode {
-		case MODE_ESCAPE:
-			p.parseEscape(char)
-		case MODE_NORMAL:
-			p.parseNormal(char)
-		}
-	}
-}
-
-func (p *parser) parseEscape(char rune) {
-	p.escape.buffer = append(p.escape.buffer, char)
-	if len(p.escape.buffer) == 2 {
-		if char != '[' {
-			// Not really an escape code, abort
-			p.screen.appendMany(p.escape.buffer)
-			p.mode = MODE_NORMAL
-		}
-	} else {
-		char = unicode.ToUpper(char)
-		switch char {
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			p.escape.nextInstruction = append(p.escape.nextInstruction, char)
-		case ';':
-			p.escape.endOfInstruction()
-		case 'Q', 'K', 'G', 'A', 'B', 'C', 'D', 'M':
-			p.escape.code = char
-			p.escape.endOfInstruction()
-			p.screen.applyEscape(p.escape)
-			p.mode = MODE_NORMAL
-		default:
-			// abort the escapeCode
-			p.screen.appendMany(p.escape.buffer)
-			p.mode = MODE_NORMAL
-		}
-	}
-}
-
-func (p *parser) parseNormal(char rune) {
-	switch char {
-	case '\n':
-		p.screen.x = 0
-		p.screen.y++
-	case '\r':
-		p.screen.x = 0
-	case '\b':
-		if p.screen.x > 0 {
-			p.screen.x--
-		}
-	case '\x1b':
-		p.escape = escapeCode{buffer: []rune{char}}
-		p.mode = MODE_ESCAPE
-	default:
-		p.screen.append(char)
-	}
+	p.parse(ansi)
 }
 
 func (s *screen) asHTML() []byte {

--- a/screen.go
+++ b/screen.go
@@ -161,3 +161,18 @@ func (s *screen) asHTML() []byte {
 
 	return []byte(strings.Join(lines, "\n"))
 }
+
+func (s *screen) newLine() {
+	s.x = 0
+	s.y++
+}
+
+func (s *screen) carriageReturn() {
+	s.x = 0
+}
+
+func (s *screen) backspace() {
+	if s.x > 0 {
+		s.x--
+	}
+}

--- a/terminal.go
+++ b/terminal.go
@@ -15,7 +15,7 @@ import "bytes"
 // Render converts ANSI to HTML and returns the result.
 func Render(input []byte) []byte {
 	screen := screen{}
-	screen.render(input)
+	screen.parse(input)
 	output := bytes.Replace(screen.asHTML(), []byte("\n\n"), []byte("\n&nbsp;\n"), -1)
 	return output
 }

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -142,7 +142,7 @@ var rendererTestCases = []struct {
 	}, {
 		`escapes HTML in color codes`,
 		"hello \x1b[\"hellomfriend",
-		"hello \x1b[&quot;hellomfriend",
+		"hello [&quot;hellomfriend",
 	}, {
 		`handles background colors`,
 		"\x1b[30;42m\x1b[2KOK (244 tests, 558 assertions)",
@@ -152,9 +152,9 @@ var rendererTestCases = []struct {
 		"\x1b[38;5;169mhello\x1b[0m \x1b[38;5;179mgoodbye",
 		"<span class=\"term-fgx169\">hello</span> <span class=\"term-fgx179\">goodbye</span>",
 	}, {
-		`ignores broken escape characters`,
+		`ignores broken escape characters, stripping the escape rune itself`,
 		"hi amazing \x1b[12 nom nom nom friends",
-		"hi amazing \x1b[12 nom nom nom friends",
+		"hi amazing [12 nom nom nom friends",
 	}, {
 		`handles colors with 3 attributes`,
 		"\x1b[0;10;4m\x1b[1m\x1b[34mgood news\x1b[0;10m\n\neveryone",


### PR DESCRIPTION
The parser state machine was originally written as a performance testing exercise as the original regex was the last big performance bottleneck.

Unfortunately, it was pretty awful code.

This rewrites the state machine so that it's easier to understand and also introduces a performance boost for escape code heavy files.