### PR TITLE
Fix parameter-less resets

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -132,5 +132,7 @@ func (p *parser) handlePreEscape(char rune) {
 
 func (p *parser) addInstruction() {
 	instruction := string(p.ansi[p.instructionStartedAt:p.cursor])
-	p.instructions = append(p.instructions, instruction)
+	if instruction != "" {
+		p.instructions = append(p.instructions, instruction)
+	}
 }

--- a/style.go
+++ b/style.go
@@ -56,11 +56,7 @@ func (s *style) addOther(r string) {
 // Add colours to an existing style, potentially returning
 // a new style.
 func (s *style) color(colors []string) *style {
-	if len(colors) == 0 {
-		return s
-	}
-
-	if len(colors) == 1 && colors[0] == "0" {
+	if len(colors) == 1 && (colors[0] == "0" || colors[0] == "") {
 		// Shortcut for full style reset
 		return &emptyStyle
 	}

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -50,6 +50,10 @@ var rendererTestCases = []struct {
 		"he\x1b[32m\x1b[33m\bllo",
 		"h<span class=\"term-fg33\">llo</span>",
 	}, {
+		`handles \x1b[m (no parameter) as a reset`,
+		"\x1b[36mthis has a color\x1b[mthis is normal now\r\n",
+		"<span class=\"term-fg36\">this has a color</span>this is normal now",
+	}, {
 		`treats \x1b[39m as a reset`,
 		"\x1b[36mthis has a color\x1b[39mthis is normal now\r\n",
 		"<span class=\"term-fg36\">this has a color</span>this is normal now",


### PR DESCRIPTION
If you're a hipster and use `$(tput sgr0)` (instead of `\033[0m`) then you'll get the escape sequence `\033[m`, which [according to Wikipedia](http://en.wikipedia.org/wiki/ANSI_escape_code) is a valid way of doing a reset:

> After CSI can be zero or more parameters separated with ;. With no parameters, CSI m is treated as CSI 0 m (reset / normal), which is typical of most of the ANSI escape sequences.

We should treat `\033[m` the same as `\033[0m`

Fixes #28