### PR TITLE
Readability improvements & documentation

### DIFF
--- a/output.go
+++ b/output.go
@@ -11,7 +11,12 @@ type outputBuffer struct {
 
 func (b *outputBuffer) appendNodeStyle(n node) {
 	b.buf.Write([]byte(`<span class="`))
-	b.buf.Write([]byte(n.style.asClasses()))
+	for idx, class := range n.style.asClasses() {
+		if idx > 0 {
+			b.buf.Write([]byte(" "))
+		}
+		b.buf.Write([]byte(class))
+	}
 	b.buf.Write([]byte(`">`))
 }
 

--- a/parser.go
+++ b/parser.go
@@ -6,10 +6,10 @@ import (
 )
 
 const (
-	MODE_NORMAL       = iota
-	MODE_PRE_ESCAPE   = iota
-	MODE_ESCAPE       = iota
-	MODE_ITERM_ESCAPE = iota
+	MODE_NORMAL         = iota
+	MODE_PRE_ESCAPE     = iota
+	MODE_ESCAPE         = iota
+	MODE_ELEMENT_ESCAPE = iota
 )
 
 // Stateful ANSI parser
@@ -22,6 +22,39 @@ type parser struct {
 	instructions         []string
 	instructionStartedAt int
 }
+
+/*
+ * How this state machine works:
+ *
+ * We start in MODE_NORMAL. We're not inside an escape sequence. In this mode
+ * most input is written directly to the screen. If we receive a newline,
+ * backspace or other cursor-moving signal, we let the screen know so that it
+ * can change the location of its cursor accordingly.
+ *
+ * If we're in MODE_NORMAL and we receive an escape character (\x1b) we enter
+ * MODE_PRE_ESCAPE. In this mode we know we might be able to enter an escape
+ * sequence, but we're not sure whether it's a regular escape sequence, one
+ * of our special element sequences, or an invalid sequence.
+ *
+ * If we're in MODE_PRE_ESCAPE and we receive a [, we enter
+ * MODE_ESCAPE. If we instead receive a ] we enter MODE_ELEMENT_ESCAPE. In
+ * both cases we start our instruction buffer. The instruction buffer is used
+ * to store the individual characters that make up ANSI instructions before
+ * sending them to the screen. If we receive neither of these characters,
+ * we treat this as an invalid escape and return to MODE_NORMAL.
+ *
+ * If we're in MODE_ESCAPE, we expect to receive a sequence of characters
+ * looking like 1;30;42m. That's an instruction to turn on bold, set the
+ * foreground colour to black and the background colour to green. We receive
+ * these characters one by one turning them in to instruction parts (1, 30, 42)
+ * followed by an instruction type (m). Once the instruction type is received
+ * we send it and its parts to the screen and return to MODE_NORMAL.
+ *
+ * If we're in MODE_ELEMENT_ESCAPE, we expect to receive a sequence of
+ * characters up to and including a bell (\a). We skip forward until this bell
+ * is reached, then send everything from when we entered MODE_ELEMENT_ESCAPE
+ * up to the bell to parseElementSequence and return to MODE_NORMAL.
+ */
 
 func parseANSIToScreen(s *screen, ansi []byte) {
 	p := parser{mode: MODE_NORMAL, ansi: ansi, screen: s}
@@ -37,9 +70,9 @@ func parseANSIToScreen(s *screen, ansi []byte) {
 		case MODE_PRE_ESCAPE:
 			// We've received an escape character but aren't inside an escape sequence yet
 			p.handlePreEscape(char)
-		case MODE_ITERM_ESCAPE:
-			// We're inside an iTerm escape sequence, capture until we hit a bell character
-			p.handleItermEscape(char)
+		case MODE_ELEMENT_ESCAPE:
+			// We're inside an element escape sequence, capture until we hit a bell character
+			p.handleElementEscape(char)
 		case MODE_NORMAL:
 			// Outside of an escape sequence entirely, normal input
 			p.handleNormal(char)
@@ -49,7 +82,7 @@ func parseANSIToScreen(s *screen, ansi []byte) {
 	}
 }
 
-func (p *parser) handleItermEscape(char rune) {
+func (p *parser) handleElementEscape(char rune) {
 	if char != '\a' {
 		return
 	}
@@ -74,7 +107,7 @@ func (p *parser) handleItermEscape(char rune) {
 	}
 
 	if err != nil {
-		p.screen.appendMany([]rune("*** Error parsing iTerm2 image escape sequence: "))
+		p.screen.appendMany([]rune("*** Error parsing custom element escape sequence: "))
 		p.screen.appendMany([]rune(err.Error()))
 	} else {
 		p.screen.appendElement(image)
@@ -129,7 +162,7 @@ func (p *parser) handlePreEscape(char rune) {
 		p.mode = MODE_ESCAPE
 	case ']':
 		p.instructionStartedAt = p.cursor + utf8.RuneLen('[')
-		p.mode = MODE_ITERM_ESCAPE
+		p.mode = MODE_ELEMENT_ESCAPE
 	default:
 		// Not an escape code, false alarm
 		p.cursor = p.escapeStartedAt

--- a/style.go
+++ b/style.go
@@ -25,10 +25,6 @@ func (s *style) isEqual(o *style) bool {
 func (s *style) asClasses() []string {
 	var styles []string
 
-	if s.isEmpty() {
-		return styles
-	}
-
 	if s.fgColor > 0 && s.fgColor < 38 && !s.fgColorX {
 		styles = append(styles, "term-fg"+strconv.Itoa(int(s.fgColor)))
 	}
@@ -84,7 +80,6 @@ func (s *style) color(colors []string) *style {
 	}
 
 	newStyle := style(*s)
-	oldStyle := s
 	s = &newStyle
 
 	if len(colors) > 2 {
@@ -155,11 +150,5 @@ func (s *style) color(colors []string) *style {
 			s.bgColorX = false
 		}
 	}
-	if s.isEmpty() {
-		return &emptyStyle
-	} else if *s == *oldStyle {
-		return oldStyle
-	} else {
-		return s
-	}
+	return s
 }

--- a/style.go
+++ b/style.go
@@ -1,56 +1,78 @@
 package terminal
 
 import "strings"
+import "strconv"
 
 var emptyStyle = style{}
 
 type style struct {
-	fgColor     string
-	bgColor     string
-	otherColors string
-	classes     string
+	fgColor   uint8
+	bgColor   uint8
+	fgColorX  bool
+	bgColorX  bool
+	bold      bool
+	faint     bool
+	italic    bool
+	underline bool
+	strike    bool
 }
 
 // True if both styles are equal (or are the same object)
 func (s *style) isEqual(o *style) bool {
-	return s == o || (s.fgColor == o.fgColor && s.bgColor == o.bgColor && s.otherColors == o.otherColors)
+	return s == o || *s == *o
 }
 
 // CSS classes that make up the style
 func (s *style) asClasses() string {
-	if s.classes != "" || s.isEmpty() {
-		return s.classes
+	if s.isEmpty() {
+		return ""
 	}
 
 	var styles []string
-	if s.fgColor != "" {
-		styles = append(styles, s.fgColor)
+	if s.fgColor > 0 && s.fgColor < 38 && !s.fgColorX {
+		styles = append(styles, "term-fg"+strconv.Itoa(int(s.fgColor)))
 	}
-	if s.bgColor != "" {
-		styles = append(styles, s.bgColor)
+	if s.fgColor > 38 && !s.fgColorX {
+		styles = append(styles, "term-fgi"+strconv.Itoa(int(s.fgColor)))
+
 	}
-	if s.otherColors != "" {
-		styles = append(styles, s.otherColors)
+	if s.fgColorX {
+		styles = append(styles, "term-fgx"+strconv.Itoa(int(s.fgColor)))
+
 	}
-	s.classes = strings.TrimSpace(strings.Join(styles, " "))
-	return s.classes
+
+	if s.bgColor > 0 && s.bgColor < 48 && !s.bgColorX {
+		styles = append(styles, "term-bg"+strconv.Itoa(int(s.bgColor)))
+	}
+	if s.bgColor > 48 && !s.bgColorX {
+		styles = append(styles, "term-bgi"+strconv.Itoa(int(s.bgColor)))
+	}
+	if s.bgColorX {
+		styles = append(styles, "term-bgx"+strconv.Itoa(int(s.bgColor)))
+	}
+
+	if s.bold {
+		styles = append(styles, "term-fg1")
+	}
+	if s.faint {
+		styles = append(styles, "term-fg2")
+	}
+	if s.italic {
+		styles = append(styles, "term-fg3")
+	}
+	if s.underline {
+		styles = append(styles, "term-fg4")
+	}
+	if s.strike {
+		styles = append(styles, "term-fg9")
+	}
+
+	return strings.Join(styles, " ")
 }
 
 // True if style is empty
 func (s *style) isEmpty() bool {
-	return s.fgColor == "" && s.bgColor == "" && s.otherColors == ""
-}
-
-// Remove a particular 'other' colour from our style's colour list
-func (s *style) removeOther(r string) {
-	s.otherColors = strings.Replace(s.otherColors, r+" ", "", -1)
-}
-
-func (s *style) addOther(r string) {
-	r = r + " "
-	if strings.Index(s.otherColors, r) == -1 {
-		s.otherColors = s.otherColors + r
-	}
+	return *s == style{}
 }
 
 // Add colours to an existing style, potentially returning
@@ -61,61 +83,88 @@ func (s *style) color(colors []string) *style {
 		return &emptyStyle
 	}
 
-	s = &style{fgColor: s.fgColor, bgColor: s.bgColor, otherColors: s.otherColors}
+	newStyle := style(*s)
+	s = &newStyle
 
-	if len(colors) >= 2 {
+	if len(colors) > 2 {
+		cc, err := strconv.ParseUint(colors[2], 10, 8)
+		if err != nil {
+			return s
+		}
 		if colors[0] == "38" && colors[1] == "5" {
 			// Extended set foreground x-term color
-			s.fgColor = "term-fgx" + colors[2]
+			s.fgColor = uint8(cc)
+			s.fgColorX = true
 			return s
 		}
 
 		// Extended set background x-term color
 		if colors[0] == "48" && colors[1] == "5" {
-			s.bgColor = "term-bgx" + colors[2]
+			s.bgColor = uint8(cc)
+			s.bgColorX = true
 			return s
 		}
 	}
 
-	for _, cc := range colors {
+	for _, ccs := range colors {
 		// If multiple colors are defined, i.e. \e[30;42m\e then loop through each
 		// one, and assign it to s.fgColor or s.bgColor
+		cc, err := strconv.ParseUint(ccs, 10, 8)
+		if err != nil {
+			continue
+		}
+
 		switch cc {
-		case "0":
+		case 0:
 			// Reset all styles - don't use &emptyStyle here as we could end up adding colours
 			// in this same action.
 			s = &style{}
-		case "21", "22":
-			s.removeOther("term-fg1")
-			s.removeOther("term-fg2")
+		case 1:
+			s.bold = true
+			s.faint = false
+		case 2:
+			s.faint = true
+			s.bold = false
+		case 3:
+			s.italic = true
+		case 4:
+			s.underline = true
+		case 9:
+			s.strike = true
+		case 21, 22:
+			s.bold = false
+			s.faint = false
 			// Turn off italic
-		case "23":
-			s.removeOther("term-fg3")
+		case 23:
+			s.italic = false
 			// Turn off underline
-		case "24":
-			s.removeOther("term-fg4")
+		case 24:
+			s.underline = false
 			// Turn off crossed-out
-		case "29":
-			s.removeOther("term-fg9")
-		case "39":
-			s.fgColor = ""
-		case "49":
-			s.bgColor = ""
+		case 29:
+			s.strike = false
+		case 39:
+			s.fgColor = 0
+			s.fgColorX = false
+		case 49:
+			s.bgColor = 0
+			s.bgColorX = false
 			// 30–37, then it's a foreground color
-		case "30", "31", "32", "33", "34", "35", "36", "37":
-			s.fgColor = "term-fg" + cc
+		case 30, 31, 32, 33, 34, 35, 36, 37:
+			s.fgColor = uint8(cc)
+			s.fgColorX = false
 			// 40–47, then it's a background color.
-		case "40", "41", "42", "43", "44", "45", "46", "47":
-			s.bgColor = "term-bg" + cc
+		case 40, 41, 42, 43, 44, 45, 46, 47:
+			s.bgColor = uint8(cc)
+			s.bgColorX = false
 			// 90-97 is like the regular fg color, but high intensity
-		case "90", "91", "92", "93", "94", "95", "96", "97":
-			s.fgColor = "term-fgi" + cc
+		case 90, 91, 92, 93, 94, 95, 96, 97:
+			s.fgColor = uint8(cc)
+			s.fgColorX = false
 			// 100-107 is like the regular bg color, but high intensity
-		case "100", "101", "102", "103", "104", "105", "106", "107":
-			s.fgColor = "term-bgi" + cc
-			// 1-9 random other styles
-		case "1", "2", "3", "4", "5", "6", "7", "8", "9":
-			s.addOther("term-fg" + cc)
+		case 100, 101, 102, 103, 104, 105, 106, 107:
+			s.bgColor = uint8(cc)
+			s.bgColorX = false
 		}
 	}
 	return s

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -208,7 +208,7 @@ var rendererTestCases = []struct {
 	}, {
 		`prints on error on malformed iTerm2 image codes`,
 		"\x1b]1337;;;;\a",
-		"*** Error parsing iTerm2 image escape sequence: expected sequence to start with 1337;File=, 1338; or 1339;, got &quot;1337;;;;&quot; instead",
+		"*** Error parsing custom element escape sequence: expected sequence to start with 1337;File=, 1338; or 1339;, got &quot;1337;;;;&quot; instead",
 	}, {
 		`correctly handles images that we decide not to render`,
 		"hi\x1b]1337;File=name=MS5naWY=;inline=0:AA==\ahello",

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -172,7 +172,7 @@ var rendererTestCases = []struct {
 	}, {
 		`handles colors with 3 attributes`,
 		"\x1b[0;10;4m\x1b[1m\x1b[34mgood news\x1b[0;10m\n\neveryone",
-		"<span class=\"term-fg34 term-fg4 term-fg1\">good news</span>\n&nbsp;\neveryone",
+		"<span class=\"term-fg34 term-fg1 term-fg4\">good news</span>\n&nbsp;\neveryone",
 	}, {
 		`ends underlining with \x1b[24`,
 		"\x1b[4mbegin\x1b[24m\r\nend",


### PR DESCRIPTION
Adds documentation to the parser state machine, as the last time I looked at it I didn't understand how it worked.

Changes `style.go` and the related type to be able the style it represents rather than CSS classes, making it slightly easier to understand how and why it works.