### PR TITLE
Ignore unsupported element sequences

### DIFF
--- a/element.go
+++ b/element.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"mime"
 	"strings"
@@ -22,6 +23,8 @@ type element struct {
 	width       string
 	elementType int
 }
+
+var errUnsupportedElementSequence = errors.New("Unsupported element sequence")
 
 func (i *element) asHTML() string {
 	if i.elementType == ELEMENT_LINK {
@@ -59,6 +62,9 @@ func parseElementSequence(sequence string) (*element, error) {
 
 	arguments, elementType, content, err := splitAndVerifyElementSequence(sequence)
 	if err != nil {
+		if err == errUnsupportedElementSequence {
+			err = nil
+		}
 		return nil, err
 	}
 
@@ -157,10 +163,7 @@ func splitAndVerifyElementSequence(s string) (arguments string, elementType int,
 
 	prefixLen := len("1337;File=")
 	if !strings.HasPrefix(s, "1337;File=") {
-		if len(s) > prefixLen {
-			s = s[:prefixLen] // Don't blow out our error output
-		}
-		return "", 0, "", fmt.Errorf("expected sequence to start with 1337;File=, 1338; or 1339;, got %q instead", s)
+		return "", 0, "", errUnsupportedElementSequence
 	}
 	s = s[prefixLen:]
 

--- a/element_test.go
+++ b/element_test.go
@@ -11,14 +11,6 @@ var errorCases = []struct {
 	expected string
 }{
 	{
-		`sequence does not begin with 1337;File= or 1338;`,
-		"foobar",
-		`expected sequence to start with 1337;File=, 1338; or 1339;, got "foobar" instead`,
-	}, {
-		`sequence beginning error is cropped`,
-		"123456789012345678901234567890123456789012345678901234567890",
-		`expected sequence to start with 1337;File=, 1338; or 1339;, got "1234567890" instead`,
-	}, {
 		`1337: sequence does not have a content part and a arguments part`,
 		"1337;File=foobar",
 		`expected sequence to have one arguments part and one content part, got 1 part(s)`,
@@ -59,6 +51,10 @@ var validCases = []struct {
 	expected *element
 }{
 	{
+		`unsupported escape sequence`,
+		"9999",
+		nil,
+	}, {
 		`1337: image with name, content & inline`,
 		`1337;File=name=Zm9vLmdpZg==;inline=1:AA==`,
 		&element{url: "foo.gif", content: "AA==", contentType: "image/gif", elementType: ELEMENT_ITERM_IMAGE},

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -211,9 +211,9 @@ var rendererTestCases = []struct {
 		"\x1b]1337;File=name=MS5naWY=;inline=1:AA==\a",
 		`<img alt="1.gif" src="data:image/gif;base64,AA==">`,
 	}, {
-		`prints on error on malformed iTerm2 image codes`,
-		"\x1b]1337;;;;\a",
-		"*** Error parsing custom element escape sequence: expected sequence to start with 1337;File=, 1338; or 1339;, got &quot;1337;;;;&quot; instead",
+		`silently ignores unsupported ANSI escape sequences`,
+		"abc\x1b]9999\aghi",
+		"abcghi",
 	}, {
 		`correctly handles images that we decide not to render`,
 		"hi\x1b]1337;File=name=MS5naWY=;inline=0:AA==\ahello",


### PR DESCRIPTION
If terminal-to-html encounters an unsupported element sequences such as `ESC ]2;foobar ^G` ([set window title](http://www.tldp.org/HOWTO/Xterm-Title-3.html)), it outputs an error message.

The Apple Terminal and iTerm2 simply ignores unknown sequences. This patch makes terminal-to-html do the same.